### PR TITLE
Support various request methods for /delay

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -389,7 +389,7 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
     return jsonify(authenticated=True, user=user)
 
 
-@app.route('/delay/<int:delay>')
+@app.route('/delay/<int:delay>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'TRACE'])
 def delay_response(delay):
     """Returns a delayed response"""
     delay = min(delay, 10)
@@ -397,7 +397,7 @@ def delay_response(delay):
     time.sleep(delay)
 
     return jsonify(get_dict(
-        'url', 'args', 'form', 'data', 'origin', 'headers', 'files'))
+        'url', 'args', 'form', 'data', 'origin', 'headers', 'files', 'json'))
 
 @app.route('/drip')
 def drip():


### PR DESCRIPTION
Add `POST`, `PUT`, `DELETE`, `PATCH` and `TRACE` methods to the allowed list for `/delay/<int:delay>`; also return `json` (similar to the special methods for the added request types).
