### PR TITLE
removing the need for the six module while keeping Py2/3 compatibility

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -19,7 +19,11 @@ from flask import Flask, Response, request, render_template, redirect, jsonify, 
 from werkzeug.datastructures import WWWAuthenticate
 from werkzeug.http import http_date
 from werkzeug.wrappers import BaseResponse
-from six.moves import range as xrange
+
+try:
+    xrange
+except NameError:
+    xrange = range
 
 from . import filters
 from .helpers import get_headers, status_code, get_dict, check_basic_auth, check_digest_auth, H, ROBOT_TXT, ANGRY_ASCII

--- a/httpbin/filters.py
+++ b/httpbin/filters.py
@@ -12,11 +12,7 @@ import zlib
 
 from decimal import Decimal
 from time import time as now
-
-try:
-    from io import BytesIO
-except ImportError:
-    from StringIO import StringIO as BytesIO
+from io import BytesIO
 
 from decorator import decorator
 from flask import Flask, Response

--- a/httpbin/filters.py
+++ b/httpbin/filters.py
@@ -10,9 +10,13 @@ This module provides response filter decorators.
 import gzip as gzip2
 import zlib
 
-from six import BytesIO
 from decimal import Decimal
 from time import time as now
+
+try:
+    from io import BytesIO
+except ImportError:
+    from StringIO import StringIO as BytesIO
 
 from decorator import decorator
 from flask import Flask, Response

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -13,7 +13,11 @@ from hashlib import md5
 from werkzeug.http import parse_authorization_header
 
 from flask import request, make_response
-from six.moves.urllib.parse import urlparse, urlunparse
+
+try:
+    from urlparse import urlparse, urlunparse
+except ImportError:
+    from urllib.parse import urlparse, urlunparse
 
 
 from .structures import CaseInsensitiveDict

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ gunicorn==18.0
 itsdangerous==0.24
 Jinja2==2.7.2
 MarkupSafe==0.23
-six==1.6.1
 Werkzeug==0.9.4

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
     ],
     packages=find_packages(),
     include_package_data = True, # include files listed in MANIFEST.in
-    install_requires=['Flask','MarkupSafe','decorator','itsdangerous','six'],
+    install_requires=['Flask','MarkupSafe','decorator','itsdangerous'],
 )

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 import base64
 import unittest
-import six
 import json
+import sys
 from werkzeug.http import parse_dict_header
 from hashlib import md5
-from six import BytesIO
+from io import BytesIO
 
 import httpbin
 
@@ -195,7 +195,7 @@ class HttpbinTestCase(unittest.TestCase):
         # The RNG changed in python3, so even though we are
         # setting the seed, we can't expect the value to be the
         # same across both interpreters.
-        if six.PY3:
+        if sys.version_info[0] > 2:
             self.assertEqual(
                 response.data, b'\xc5\xd7\x14\x84\xf8\xcf\x9b\xf4\xb7o'
             )
@@ -214,7 +214,7 @@ class HttpbinTestCase(unittest.TestCase):
         # The RNG changed in python3, so even though we are
         # setting the seed, we can't expect the value to be the
         # same across both interpreters.
-        if six.PY3:
+        if sys.version_info[0] > 2:
             self.assertEqual(
                 response.data, b'\xc5\xd7\x14\x84\xf8\xcf\x9b\xf4\xb7o'
             )


### PR DESCRIPTION
I noticed that there is relatively little use of the six module in the project, and these minor changes remove the need altogether.
