### PR TITLE
new digest-auth-nocookie route and improved robustness of digest-auth

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -370,31 +370,31 @@ def hidden_basic_auth(user='user', passwd='passwd'):
 
 
 @app.route('/digest-auth/<qop>/<user>/<passwd>')
-@app.route('/digest-auth-nocookie/<qop>/<user>/<passwd>', defaults={'checkCookie':False})
-def digest_auth(qop=None, user='user', passwd='passwd', checkCookie=True):
+@app.route('/digest-auth-nocookie/<qop>/<user>/<passwd>', defaults={'check_cookie':False})
+def digest_auth(qop=None, user='user', passwd='passwd', check_cookie=True):
     """Prompts the user for authorization using HTTP Digest auth"""
     if qop not in ('auth', 'auth-int'):
         qop = None
     try:
-        remoteAddr = request.remote_addr or u''
-        authInHeaders = 'Authorization' in request.headers
-        digestCheck = authInHeaders and request.headers.get('Authorization').startswith('Digest ')
-        authCheck = authInHeaders and digestCheck and check_digest_auth(user, passwd)
-        if not all([authInHeaders, digestCheck, authCheck]):
+        remote_addr = request.remote_addr or u''
+        auth_in_headers = 'Authorization' in request.headers
+        digest_check = auth_in_headers and request.headers.get('Authorization').startswith('Digest ')
+        auth_check = auth_in_headers and digest_check and check_digest_auth(user, passwd)
+        if not all([auth_in_headers, digest_check, auth_check]):
             # RFC2616 Section4.2: HTTP headers are ASCII.  That means
             # request.remote_addr was originally ASCII, so I should be able to
             # encode it back to ascii.  Also, RFC2617 says about nonces: "The
             # contents of the nonce are implementation dependent"
             nonce = H(b':'.join([
-                remoteAddr.encode('ascii'),
+                remote_addr.encode('ascii'),
                 str(time.time()).encode('ascii'),
                 os.urandom(10)
             ]))
             opaque = H(os.urandom(10))
             
             response = app.make_response(jsonify(
-                authenticated=False, user=user, authInHeaders=authInHeaders,
-                digestCheck=digestCheck, authCheck=authCheck,
+                authenticated=False, user=user, auth_in_headers=auth_in_headers,
+                digest_check=digest_check, auth_check=auth_check,
                 headers=dict(request.headers)))
             response.status_code = 401
             
@@ -402,10 +402,10 @@ def digest_auth(qop=None, user='user', passwd='passwd', checkCookie=True):
             auth.set_digest('me@kennethreitz.com', nonce, opaque=opaque,
                             qop=('auth', 'auth-int') if qop is None else (qop, ))
             response.headers['WWW-Authenticate'] = auth.to_header()
-            if checkCookie is True:
-                response.headers['Set-Cookie'] = 'auth=%s' % remoteAddr
+            if check_cookie is True:
+                response.headers['Set-Cookie'] = 'auth=%s' % remote_addr
             return response
-        elif checkCookie is True and request.cookies.get('auth') != remoteAddr:
+        elif check_cookie is True and request.cookies.get('auth') != remote_addr:
             # check for auth challange cookie per https://github.com/Runscope/httpbin/issues/124
             response = app.make_response('Missing the cookie set in the 401 response. '
                 'This client seems broken. To bypass this check use the digest-auth-nocookie route.')
@@ -427,6 +427,7 @@ def delay_response(delay):
 
     return jsonify(get_dict(
         'url', 'args', 'form', 'data', 'origin', 'headers', 'files'))
+
 
 @app.route('/drip')
 def drip():

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -370,34 +370,50 @@ def hidden_basic_auth(user='user', passwd='passwd'):
 
 
 @app.route('/digest-auth/<qop>/<user>/<passwd>')
-def digest_auth(qop=None, user='user', passwd='passwd'):
+@app.route('/digest-auth-nocookie/<qop>/<user>/<passwd>', defaults={'checkCookie':False})
+def digest_auth(qop=None, user='user', passwd='passwd', checkCookie=True):
     """Prompts the user for authorization using HTTP Digest auth"""
     if qop not in ('auth', 'auth-int'):
         qop = None
-    if 'Authorization' not in request.headers or  \
-                       not check_digest_auth(user, passwd) or \
-                       not 'Cookie' in request.headers:
-        response = app.make_response('')
-        response.status_code = 401
-
-        # RFC2616 Section4.2: HTTP headers are ASCII.  That means
-        # request.remote_addr was originally ASCII, so I should be able to
-        # encode it back to ascii.  Also, RFC2617 says about nonces: "The
-        # contents of the nonce are implementation dependent"
-        nonce = H(b''.join([
-            getattr(request,'remote_addr',u'').encode('ascii'),
-            b':',
-            str(time.time()).encode('ascii'),
-            b':',
-            os.urandom(10)
-        ]))
-        opaque = H(os.urandom(10))
-
-        auth = WWWAuthenticate("digest")
-        auth.set_digest('me@kennethreitz.com', nonce, opaque=opaque,
-                        qop=('auth', 'auth-int') if qop is None else (qop, ))
-        response.headers['WWW-Authenticate'] = auth.to_header()
-        response.headers['Set-Cookie'] = 'fake=fake_value'
+    try:
+        remoteAddr = request.remote_addr or u''
+        authInHeaders = 'Authorization' in request.headers
+        digestCheck = authInHeaders and request.headers.get('Authorization').startswith('Digest ')
+        authCheck = authInHeaders and digestCheck and check_digest_auth(user, passwd)
+        if not all([authInHeaders, digestCheck, authCheck]):
+            # RFC2616 Section4.2: HTTP headers are ASCII.  That means
+            # request.remote_addr was originally ASCII, so I should be able to
+            # encode it back to ascii.  Also, RFC2617 says about nonces: "The
+            # contents of the nonce are implementation dependent"
+            nonce = H(b':'.join([
+                remoteAddr.encode('ascii'),
+                str(time.time()).encode('ascii'),
+                os.urandom(10)
+            ]))
+            opaque = H(os.urandom(10))
+            
+            response = app.make_response(jsonify(
+                authenticated=False, user=user, authInHeaders=authInHeaders,
+                digestCheck=digestCheck, authCheck=authCheck,
+                headers=dict(request.headers)))
+            response.status_code = 401
+            
+            auth = WWWAuthenticate("digest")
+            auth.set_digest('me@kennethreitz.com', nonce, opaque=opaque,
+                            qop=('auth', 'auth-int') if qop is None else (qop, ))
+            response.headers['WWW-Authenticate'] = auth.to_header()
+            if checkCookie is True:
+                response.headers['Set-Cookie'] = 'auth=%s' % remoteAddr
+            return response
+        elif checkCookie is True and request.cookies.get('auth') != remoteAddr:
+            # check for auth challange cookie per https://github.com/Runscope/httpbin/issues/124
+            response = app.make_response('Missing the cookie set in the 401 response. '
+                'This client seems broken. To bypass this check use the digest-auth-nocookie route.')
+            response.status_code = 403
+            return response
+    except Exception as e:
+        response = app.make_response('Error: %s' % str(e))
+        response.status_code = 500
         return response
     return jsonify(authenticated=True, user=user)
 

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -274,7 +274,7 @@ def HA2(credentails, request):
     raise ValueError
 
 
-def response(credentails, password, request):
+def response(credentails, user, password, request):
     """Compile digest auth response
 
     If the qop directive's value is "auth" or "auth-int" , then compute the response as follows:
@@ -284,13 +284,17 @@ def response(credentails, password, request):
 
     Arguments:
     - `credentails`: credentails dict
+    - `user`: request user name
     - `password`: request user password
     - `request`: request dict
     """
+    for key in 'nonce', 'realm':
+        if key not in credentails:
+            raise ValueError("%s required for response" % key)
     response = None
     HA1_value = HA1(
         credentails.get('realm'),
-        credentails.get('username'),
+        user,
         password
     )
     HA2_value = HA2(credentails, request)
@@ -322,8 +326,8 @@ def check_digest_auth(user, passwd):
     if request.headers.get('Authorization'):
         credentails = parse_authorization_header(request.headers.get('Authorization'))
         if not credentails:
-            return
-        response_hash = response(credentails, passwd, dict(uri=request.path,
+            return False
+        response_hash = response(credentails, user, passwd, dict(uri=request.path,
                                                            body=request.data,
                                                            method=request.method))
         if credentails.get('response') == response_hash:


### PR DESCRIPTION
This adds a new route (`/digest-auth-nocookie`) that skips the cookie written at the 401 authentication requests. Additionally it fixes username checking, avoids some cases that were causing crashes (500 responses), and does a better job of reporting missing cookies as well as crashes (500 responses).
