### PR TITLE
Expose WWW-Authenticate header for CORS & Add hidden-digest-auth service

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -434,6 +434,7 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
         auth.set_digest('me@kennethreitz.com', nonce, opaque=opaque,
                         qop=('auth', 'auth-int') if qop is None else (qop, ))
         response.headers['WWW-Authenticate'] = auth.to_header()
+        response.headers['Access-Control-Expose-Headers'] = 'WWW-Authenticate'
         response.headers['Set-Cookie'] = 'fake=fake_value'
         return response
     return jsonify(authenticated=True, user=user)

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -74,6 +74,7 @@ if os.environ.get("BUGSNAG_API_KEY") is not None:
 def set_cors_headers(response):
     response.headers['Access-Control-Allow-Origin'] = request.headers.get('Origin', '*')
     response.headers['Access-Control-Allow-Credentials'] = 'true'
+    response.headers['Access-Control-Expose-Headers'] = 'WWW-Authenticate'
 
     if request.method == 'OPTIONS':
         # Both of these headers are only used for the "preflight request"
@@ -411,7 +412,7 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
     """Prompts the user for authorization using HTTP Digest auth"""
     if qop not in ('auth', 'auth-int'):
         qop = None
-    if 'Authorization' not in request.headers or  \
+    if 'Authorization' not in request.headers or \
                        not check_digest_auth(user, passwd) or \
                        not 'Cookie' in request.headers:
         response = app.make_response('')
@@ -434,7 +435,6 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
         auth.set_digest('me@kennethreitz.com', nonce, opaque=opaque,
                         qop=('auth', 'auth-int') if qop is None else (qop, ))
         response.headers['WWW-Authenticate'] = auth.to_header()
-        response.headers['Access-Control-Expose-Headers'] = 'WWW-Authenticate'
         response.headers['Set-Cookie'] = 'fake=fake_value'
         return response
     return jsonify(authenticated=True, user=user)

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -21,7 +21,7 @@ from werkzeug.wrappers import BaseResponse
 from six.moves import range as xrange
 
 from . import filters
-from .helpers import get_headers, status_code, get_dict, check_basic_auth, check_digest_auth, secure_cookie, H, ROBOT_TXT, ANGRY_ASCII
+from .helpers import get_headers, status_code, get_dict, check_basic_auth, check_digest_auth, digest_challenge_response, secure_cookie, H, ROBOT_TXT, ANGRY_ASCII
 from .utils import weighted_choice
 from .structures import CaseInsensitiveDict
 
@@ -410,35 +410,22 @@ def hidden_basic_auth(user='user', passwd='passwd'):
 @app.route('/digest-auth/<qop>/<user>/<passwd>')
 def digest_auth(qop=None, user='user', passwd='passwd'):
     """Prompts the user for authorization using HTTP Digest auth"""
-    if qop not in ('auth', 'auth-int'):
-        qop = None
+
     if 'Authorization' not in request.headers or \
                        not check_digest_auth(user, passwd) or \
                        not 'Cookie' in request.headers:
-        response = app.make_response('')
-        response.status_code = 401
-
-        # RFC2616 Section4.2: HTTP headers are ASCII.  That means
-        # request.remote_addr was originally ASCII, so I should be able to
-        # encode it back to ascii.  Also, RFC2617 says about nonces: "The
-        # contents of the nonce are implementation dependent"
-        nonce = H(b''.join([
-            getattr(request,'remote_addr',u'').encode('ascii'),
-            b':',
-            str(time.time()).encode('ascii'),
-            b':',
-            os.urandom(10)
-        ]))
-        opaque = H(os.urandom(10))
-
-        auth = WWWAuthenticate("digest")
-        auth.set_digest('me@kennethreitz.com', nonce, opaque=opaque,
-                        qop=('auth', 'auth-int') if qop is None else (qop, ))
-        response.headers['WWW-Authenticate'] = auth.to_header()
-        response.headers['Set-Cookie'] = 'fake=fake_value'
-        return response
+        return digest_challenge_response(qop, 401)
     return jsonify(authenticated=True, user=user)
 
+@app.route('/hidden-digest-auth/<qop>/<user>/<passwd>')
+def hidden_digest_auth(qop=None, user='user', passwd='passwd'):
+    """Prompts the user for authorization using HTTP Digest auth"""
+    
+    if 'Authorization' not in request.headers or \
+                       not check_digest_auth(user, passwd) or \
+                       not 'Cookie' in request.headers:
+        return digest_challenge_response(qop, 404)
+    return jsonify(authenticated=True, user=user)
 
 @app.route('/delay/<int:delay>')
 def delay_response(delay):

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -169,6 +169,8 @@ class HttpbinTestCase(unittest.TestCase):
         )
         # make sure it returns a 401
         self.assertEqual(unauthorized_response.status_code, 401)
+        # make sure the WWW-Authenticate header is exposed for cors
+        self.assertContains(unauthorized_response.headers.get('Access-Control-Expose-Headers'), 'WWW-Authenticate')
         header = unauthorized_response.headers.get('WWW-Authenticate')
         auth_type, auth_info = header.split(None, 1)
 

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -170,7 +170,7 @@ class HttpbinTestCase(unittest.TestCase):
         # make sure it returns a 401
         self.assertEqual(unauthorized_response.status_code, 401)
         # make sure the WWW-Authenticate header is exposed for cors
-        self.assertEqual(unauthorized_response.headers.get('Access-Control-Expose-Headers'), 'WWW-Authenticate')
+        self.assertTrue('WWW-Authenticate' in unauthorized_response.headers.get('Access-Control-Expose-Headers'))
         header = unauthorized_response.headers.get('WWW-Authenticate')
         auth_type, auth_info = header.split(None, 1)
 

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -170,7 +170,7 @@ class HttpbinTestCase(unittest.TestCase):
         # make sure it returns a 401
         self.assertEqual(unauthorized_response.status_code, 401)
         # make sure the WWW-Authenticate header is exposed for cors
-        self.assertContains(unauthorized_response.headers.get('Access-Control-Expose-Headers'), 'WWW-Authenticate')
+        self.assertEqual(unauthorized_response.headers.get('Access-Control-Expose-Headers'), 'WWW-Authenticate')
         header = unauthorized_response.headers.get('WWW-Authenticate')
         auth_type, auth_info = header.split(None, 1)
 

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -37,7 +37,7 @@ def _test_digest_auth(self, path, expected_status_code):
     d = parse_dict_header(auth_info)
     a1 = b'user:' + d['realm'].encode('utf-8') + b':passwd'
     ha1 = md5(a1).hexdigest().encode('utf-8')
-    a2 = b'GET:' + uri
+    a2 = b'GET:' + uri.encode('utf-8')
     ha2 = md5(a2).hexdigest().encode('utf-8')
     a3 = ha1 + b':' + d['nonce'].encode('utf-8') + b':' + ha2
     auth_response = md5(a3).hexdigest()


### PR DESCRIPTION
Added the header Access-Control-Expose-Headers=WWW-Authenticate to the unauthorized response of digest authentication to enable ajax applications to have access to this header and perform the digest auth. Fixes #205.

Also created the 'hidden-digest-auth' service which returns 404 status coded instead of 401, preventing the browser to prompt the user for the credentials in ajax applications. Closes #209.
