### PR TITLE
[RFC] Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:trusty
+
+ADD . /httpbin
+
+RUN apt-get update -y && apt-get -y install python-pip && pip install gunicorn && pip install /httpbin
+
+EXPOSE 8080
+
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8080", "httpbin:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:trusty
 
+ENV GUNICORN_WORKERS=4
+
 ADD . /httpbin
 
 RUN apt-get update -y && apt-get -y install python-pip && pip install gunicorn && pip install /httpbin
 
 EXPOSE 8080
 
-CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8080", "httpbin:app"]
+CMD gunicorn -w "$GUNICORN_WORKERS" -b 0.0.0.0:8080 httpbin:app


### PR DESCRIPTION
For ease of deployment it might be helpful to have a Docker container that runs httpbin. This is a simple first step down that road.

Before merging, it might be worth trying to optimise this image somewhat. For example, it might be better to use Debian as the base rather than Ubuntu. It might also be worth trying to remove the artifacts of the build step, make the number of gunicorn workers parameterizable, or something else interesting. I'm happy to make those changes and test them.
