### PR TITLE
make link_page return 404 if offset is to big

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -631,6 +631,9 @@ def link_page(n, offset):
     """Generate a page containing n links to other pages which do the same."""
     n = min(max(1, n), 200) # limit to between 1 and 200 links
 
+    if (offset >= n):
+        return status_code(404)
+
     link = "<a href='/links/{0}/{1}'>{2}</a> "
 
     html = ['<html><head><title>Links</title></head><body>']


### PR DESCRIPTION
I don't know if it is wanted, but I in my oppinion it makes way more sense, if /links/5/10 returns a 404. Then one is able to test his link grabber (or whatever) to only work on existing links for example.
