### PR TITLE
Add a Brotli endpoint.

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -204,6 +204,15 @@ def view_deflate_encoded_content():
         'origin', 'headers', method=request.method, deflated=True))
 
 
+@app.route('/brotli')
+@filters.brotli
+def view_brotli_encoded_content():
+    """Returns Brotli-Encoded Data."""
+
+    return jsonify(get_dict(
+        'origin', 'headers', method=request.method, brotli=True))
+
+
 @app.route('/redirect/<int:n>')
 def redirect_n_times(n):
     """302 Redirects n times."""

--- a/httpbin/filters.py
+++ b/httpbin/filters.py
@@ -10,6 +10,8 @@ This module provides response filter decorators.
 import gzip as gzip2
 import zlib
 
+import brotli as _brotli
+
 from six import BytesIO
 from decimal import Decimal
 from time import time as now
@@ -83,6 +85,29 @@ def deflate(f, *args, **kwargs):
     if isinstance(data, Response):
         data.data = deflated_data
         data.headers['Content-Encoding'] = 'deflate'
+        data.headers['Content-Length'] = str(len(data.data))
+
+        return data
+
+    return deflated_data
+
+
+@decorator
+def brotli(f, *args, **kwargs):
+    """Brotli Flask Response Decorator"""
+
+    data = f(*args, **kwargs)
+
+    if isinstance(data, Response):
+        content = data.data
+    else:
+        content = data
+
+    deflated_data = _brotli.compress(content)
+
+    if isinstance(data, Response):
+        data.data = deflated_data
+        data.headers['Content-Encoding'] = 'brotli'
         data.headers['Content-Length'] = str(len(data.data))
 
         return data

--- a/httpbin/filters.py
+++ b/httpbin/filters.py
@@ -107,7 +107,7 @@ def brotli(f, *args, **kwargs):
 
     if isinstance(data, Response):
         data.data = deflated_data
-        data.headers['Content-Encoding'] = 'brotli'
+        data.headers['Content-Encoding'] = 'br'
         data.headers['Content-Length'] = str(len(data.data))
 
         return data

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,7 @@ setup(
     ],
     packages=find_packages(),
     include_package_data = True, # include files listed in MANIFEST.in
-    install_requires=['Flask','MarkupSafe','decorator','itsdangerous','six'],
+    install_requires=[
+        'Flask','MarkupSafe','decorator','itsdangerous','six','brotlipy'
+    ],
 )

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -236,6 +236,10 @@ class HttpbinTestCase(unittest.TestCase):
         response = self.app.get('/gzip')
         self.assertEqual(response.status_code, 200)
 
+    def test_brotli(self):
+        response = self.app.get('/brotli')
+        self.assertEqual(response.status_code, 200)
+
     def test_digest_auth_with_wrong_password(self):
         auth_header = 'Digest username="user",realm="wrong",nonce="wrong",uri="/digest-auth/user/passwd/MD5",response="wrong",opaque="wrong"'
         response = self.app.get(
@@ -488,7 +492,7 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get('ETag'), 'range1000')
         self.assertEqual(self.get_data(response), 'abcdefghijklmnop'.encode('utf8'))
         self.assertEqual(response.headers.get('Content-range'), 'bytes 0-15/1000')
-    
+
     def test_request_range_open_ended_last_6_bytes(self):
         response = self.app.get(
             '/range/26',
@@ -499,7 +503,7 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get('ETag'), 'range26')
         self.assertEqual(self.get_data(response), 'uvwxyz'.encode('utf8'))
         self.assertEqual(response.headers.get('Content-range'), 'bytes 20-25/26')
-    
+
     def test_request_range_suffix(self):
         response = self.app.get(
             '/range/26',
@@ -510,7 +514,7 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get('ETag'), 'range26')
         self.assertEqual(self.get_data(response), 'vwxyz'.encode('utf8'))
         self.assertEqual(response.headers.get('Content-range'), 'bytes 21-25/26')
-    
+
     def test_request_out_of_bounds(self):
         response = self.app.get(
             '/range/26',
@@ -522,13 +526,13 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get('ETag'), 'range26')
         self.assertEqual(len(self.get_data(response)), 0)
         self.assertEqual(response.headers.get('Content-range'), 'bytes */26')
-        
+
         response = self.app.get(
             '/range/26',
             headers={ 'Range': 'bytes=32-40',
             }
         )
-        
+
         self.assertEqual(response.status_code, 416)
         response = self.app.get(
             '/range/26',


### PR DESCRIPTION
This pull request adds an endpoint that supports the [Brotli](http://google-opensource.blogspot.co.uk/2015/09/introducing-brotli-new-compression.html) compression algorithm used as a content-encoding, alongside the current support for gzip and deflate. Chromium have announced their [intention to implement](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/xdVm8c2GOMQ) Brotli, and Firefox 44 included [their support for Brotli](https://bugzilla.mozilla.org/show_bug.cgi?id=366559). Curl also [intend to implement Brotli](http://curl.haxx.se/docs/todo.html#More_compressions). I have opened this pull request myself because the urllib3 project intends to support Brotli as well (see shazow/urllib3#713), and we needed an endpoint to test against: httpbin seemed like a good choice.

Google claims that Brotli achieves 20%-26% higher compression ratios than other compression algorithms. They claim the reference implementation decodes just as quickly as deflate in zlib, but with denser compression than LZMA and bzip2.

This implementation currently relies on the hyper project's [brotlipy](https://github.com/python-hyper/brotlipy) sub-project, a CFFI-based wrapper around the Brotli reference implementation. This is the most likely reason you may not be interested in this endpoint: it adds an extra third-party dependency, and even trickier that dependency is a CFFI-based wrapper. Brotlipy currently ships with wheels for most Windows/OS X systems, but _will_ require an install-time compile on Linux (sorry, there really isn't much we can do about that right now).
