### PR TITLE
Return the used HTTP version with /version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ Endpoint                                 Description
 `/forms/post`_                           HTML form that submits to */post*
 `/xml`_                                  Returns some XML
 `/encoding/utf8`_                        Returns page containing UTF-8 data.
+`/version`_                              Returns the used HTTP version
 ======================================   ==================================================================================================================
 
 .. _/user-agent: http://httpbin.org/user-agent
@@ -94,6 +95,7 @@ Endpoint                                 Description
 .. _/forms/post: http://httpbin.org/forms/post
 .. _/xml: http://httpbin.org/xml
 .. _/encoding/utf8: http://httpbin.org/encoding/utf8
+.. _/version: http://httpbin.org/version
 
 
 DESCRIPTION

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -719,6 +719,12 @@ def xml():
     response.headers["Content-Type"] = "application/xml"
     return response
 
+@app.route('/version')
+def view_http_version():
+    """Returns HTTP Version."""
+
+    return jsonify({'version': request.environ.get('SERVER_PROTOCOL')})
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -462,6 +462,9 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertIn('google-analytics', data)
         self.assertIn('perfectaudience', data)
 
+    def test_http_version(self):
+        response = self.app.get('/version')
+        assert '"version": "HTTP/1.1"' in response.get_data()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -463,8 +463,14 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertIn('perfectaudience', data)
 
     def test_http_version(self):
-        response = self.app.get('/version')
-        assert '"version": "HTTP/1.1"' in response.get_data()
+        response = self.app.get(
+            '/version',
+            environ_overrides={
+                'SERVER_PROTOCOL': 'HTTP/3.1',
+            }
+        )
+
+        assert '"version": "HTTP/3.1"' in response.get_data()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -470,7 +470,8 @@ class HttpbinTestCase(unittest.TestCase):
             }
         )
 
-        assert '"version": "HTTP/3.1"' in response.get_data()
+        data = response.data.decode('utf-8')
+        self.assertIn('"version": "HTTP/3.1"', data)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
While working on https://github.com/clue/php-buzz-react/pull/58 we discovered that httpbin doesn't have an endpoint for the used HTTP version. This PR adds `/version` to do just that.
