### PR TITLE
Fix error 500 on drip due to division by zero (issue #296)

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -469,13 +469,13 @@ def drip():
     numbytes = min(int(args.get('numbytes', 10)),(10 * 1024 * 1024)) # set 10MB limit
     code = int(args.get('code', 200))
 
-    delay = float(args.get('delay', 0))
-    if delay > 0:
-        time.sleep(delay)
-
     if numbytes <= 0:
         response = Response('number of bytes must be positive', status=400)
         return response
+
+    delay = float(args.get('delay', 0))
+    if delay > 0:
+        time.sleep(delay)
 
     pause = duration / numbytes
     def generate_bytes():

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -468,12 +468,16 @@ def drip():
     duration = float(args.get('duration', 2))
     numbytes = min(int(args.get('numbytes', 10)),(10 * 1024 * 1024)) # set 10MB limit
     code = int(args.get('code', 200))
-    pause = duration / numbytes
 
     delay = float(args.get('delay', 0))
     if delay > 0:
         time.sleep(delay)
 
+    if numbytes <= 0:
+        response = Response('number of bytes must be positive', status=400)
+        return response
+
+    pause = duration / numbytes
     def generate_bytes():
         for i in xrange(numbytes):
             yield u"*".encode('utf-8')

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -231,6 +231,12 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(len(response.get_data()), 400)
         self.assertEqual(response.status_code, 200)
 
+    def test_drip_with_invalid_numbytes(self):
+        for bad_num in -1, 0:
+            uri = '/drip?numbytes={0}&duration=2&delay=1'.format(bad_num)
+            response = self.app.get(uri)
+            self.assertEqual(response.status_code, 400)
+
     def test_drip_with_custom_code(self):
         response = self.app.get('/drip?numbytes=400&duration=2&code=500')
         self.assertEqual(response.content_length, 400)


### PR DESCRIPTION
Return HTTP 400 if drip parameter 'numbytes' is less or equal to zero, thus avoiding divide by zero error.