### PR TITLE
Return content-length in 'range' requests

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -598,7 +598,8 @@ def range_request(numbytes):
         response = Response(headers={
             'ETag' : 'range%d' % numbytes,
             'Accept-Ranges' : 'bytes',
-            'Content-Range' : 'bytes */%d' % numbytes
+            'Content-Range' : 'bytes */%d' % numbytes,
+            "Content-Length": str(numbytes),
             })
         response.status_code = 416
         return response
@@ -625,7 +626,9 @@ def range_request(numbytes):
         'Content-Type': 'application/octet-stream',
         'ETag' : 'range%d' % numbytes,
         'Accept-Ranges' : 'bytes',
-        'Content-Range' : content_range }
+        "Content-Length": str(numbytes),
+        'Content-Range' : content_range
+    }
 
     response = Response(generate_bytes(), headers=response_headers)
 


### PR DESCRIPTION
For 'range' requests, knowing the original content-length is important for some tests I'm running.  So I've added content-length to the returned headers, where that length is set to the value requested in the URL.