### PR TITLE
Remove form from /delete endpoint

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -183,7 +183,7 @@ def view_delete():
     """Returns DELETE Data."""
 
     return jsonify(get_dict(
-        'url', 'args', 'form', 'data', 'origin', 'headers', 'files', 'json'))
+        'url', 'args', 'data', 'origin', 'headers', 'files', 'json'))
 
 
 @app.route('/gzip')

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -350,15 +350,6 @@ class HttpbinTestCase(unittest.TestCase):
                 response.data, b'\xd8\xc2kB\x82g\xc8Mz\x95'
             )
 
-    def test_delete_endpoint_returns_body(self):
-        response = self.app.delete(
-            '/delete',
-            data={'name': 'kevin'},
-            content_type='application/x-www-form-urlencoded'
-        )
-        form_data = json.loads(response.data.decode('utf-8'))['form']
-        self.assertEqual(form_data, {'name': 'kevin'})
-
     def test_methods__to_status_endpoint(self):
         methods = [
             'GET',


### PR DESCRIPTION
This was never supposed to work according to the Flask documentation.

Fixes: #317
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>