### PR TITLE
Revert "Return content-length in 'range' requests"

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -623,8 +623,7 @@ def range_request(numbytes):
         response = Response(headers={
             'ETag' : 'range%d' % numbytes,
             'Accept-Ranges' : 'bytes',
-            'Content-Range' : 'bytes */%d' % numbytes,
-            "Content-Length": str(numbytes),
+            'Content-Range' : 'bytes */%d' % numbytes
             })
         response.status_code = 416
         return response
@@ -651,9 +650,7 @@ def range_request(numbytes):
         'Content-Type': 'application/octet-stream',
         'ETag' : 'range%d' % numbytes,
         'Accept-Ranges' : 'bytes',
-        "Content-Length": str(numbytes),
-        'Content-Range' : content_range
-    }
+        'Content-Range' : content_range }
 
     response = Response(generate_bytes(), headers=response_headers)
 


### PR DESCRIPTION
Reverts kennethreitz/httpbin#314

@kennethreitz @sigmavirus24 @Lukasa If any of you have a moment, could I get confirmation I'm not completely off base here. #259 made the decision not to include data length related headers in httpbin and allows the server to specify. Requiring a `Content-Length` header for the streamed response seems fundamentally incorrect and has broken portions of the `/range` endpoint.