### PR TITLE
fix Content-Length header values for /range endpoint

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -618,13 +618,14 @@ def range_request(numbytes):
 
     request_headers = get_headers()
     first_byte_pos, last_byte_pos = get_request_range(request_headers, numbytes)
+    range_length = (last_byte_pos+1) - first_byte_pos
 
     if first_byte_pos > last_byte_pos or first_byte_pos not in xrange(0, numbytes) or last_byte_pos not in xrange(0, numbytes):
         response = Response(headers={
             'ETag' : 'range%d' % numbytes,
             'Accept-Ranges' : 'bytes',
             'Content-Range' : 'bytes */%d' % numbytes,
-            "Content-Length": str(numbytes),
+            'Content-Length': '0',
             })
         response.status_code = 416
         return response
@@ -651,7 +652,7 @@ def range_request(numbytes):
         'Content-Type': 'application/octet-stream',
         'ETag' : 'range%d' % numbytes,
         'Accept-Ranges' : 'bytes',
-        "Content-Length": str(numbytes),
+        'Content-Length': str(range_length),
         'Content-Range' : content_range
     }
 

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -486,6 +486,7 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get('ETag'), 'range100')
         self.assertEqual(response.headers.get('Content-range'), 'bytes 10-24/100')
         self.assertEqual(response.headers.get('Accept-ranges'), 'bytes')
+        self.assertEqual(response.headers.get('Content-Length'), '15')
         self.assertEqual(self.get_data(response), 'klmnopqrstuvwxy'.encode('utf8'))
 
     def test_request_range_first_15_bytes(self):
@@ -509,6 +510,7 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get('ETag'), 'range26')
         self.assertEqual(self.get_data(response), 'uvwxyz'.encode('utf8'))
         self.assertEqual(response.headers.get('Content-range'), 'bytes 20-25/26')
+        self.assertEqual(response.headers.get('Content-Length'), '6')
 
     def test_request_range_suffix(self):
         response = self.app.get(
@@ -520,6 +522,7 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get('ETag'), 'range26')
         self.assertEqual(self.get_data(response), 'vwxyz'.encode('utf8'))
         self.assertEqual(response.headers.get('Content-range'), 'bytes 21-25/26')
+        self.assertEqual(response.headers.get('Content-Length'), '5')
 
     def test_request_out_of_bounds(self):
         response = self.app.get(
@@ -532,6 +535,7 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.headers.get('ETag'), 'range26')
         self.assertEqual(len(self.get_data(response)), 0)
         self.assertEqual(response.headers.get('Content-range'), 'bytes */26')
+        self.assertEqual(response.headers.get('Content-Length'), '0')
 
         response = self.app.get(
             '/range/26',


### PR DESCRIPTION
This supersedes #345 by fixing the value for the Content-Length for the `/range` endpoint.