### PR TITLE
Adding a /etag URL for testing If-Match and If-None-Match conditional logic

### DIFF
--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -9,6 +9,7 @@ This module provides helper functions for httpbin.
 
 import json
 import base64
+import re
 from hashlib import md5, sha256
 from werkzeug.http import parse_authorization_header
 
@@ -420,3 +421,13 @@ def get_request_range(request_headers, upper_bound):
 
     return first_byte_pos, last_byte_pos
 
+def parse_multi_value_header(header_str):
+    """Break apart an HTTP header string that is potentially a quoted, comma separated list as used in entity headers in RFC2616."""
+    parsed_parts = []
+    if header_str:
+        parts = header_str.split(',')
+        for part in parts:
+            match = re.search('\s*(W/)?\"?([^"]*)\"?\s*', part)
+            if match is not None:
+                parsed_parts.append(match.group(2))
+    return parsed_parts

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -40,6 +40,7 @@
 <li><a href="{{ url_for('view_robots_page') }}" data-bare-link="true"><code>/robots.txt</code></a> Returns some robots.txt rules.</li>
 <li><a href="{{ url_for('view_deny_page') }}" data-bare-link="true"><code>/deny</code></a> Denied by robots.txt file.</li>
 <li><a href="{{ url_for('cache') }}" data-bare-link="true"><code>/cache</code></a> Returns 200 unless an If-Modified-Since or If-None-Match header is provided, when it returns a 304.</li>
+<li><a href="{{ url_for('etag', etag='etag') }}"><code>/etag/:etag</code></a> Assumes the resource has the given etag and responds to If-None-Match header with a 200 or 304 and If-Match with a 200 or 412 as appropriate.</li>
 <li><a href="{{ url_for('cache_control', value=60) }}"><code>/cache/:n</code></a> Sets a Cache-Control header for <em>n</em> seconds.</li>
 <li><a href="{{ url_for('random_bytes', n=1024) }}"><code>/bytes/:n</code></a> Generates <em>n</em> random bytes of binary data, accepts optional <em>seed</em> integer parameter.</li>
 <li><a href="{{ url_for('stream_random_bytes', n=1024) }}"><code>/stream-bytes/:n</code></a> Streams <em>n</em> random bytes of binary data, accepts optional <em>seed</em> and <em>chunk_size</em> integer parameters.</li>


### PR DESCRIPTION
I thought it would be interesting if a client could supply an entity tag in the URL and then httpbin would execute the appropriate conditional logic based on the request's `If-Match` and `If-None-Match` headers. 

Some examples in action: 
```
$ curl -I -H 'If-None-Match: "abc"' 'http://localhost:8080/etag/abc'
HTTP/1.1 304 NOT MODIFIED

$ curl -I -H 'If-None-Match: "abcd"' 'http://localhost:8080/etag/abc'
HTTP/1.1 200 OK

$ curl -I -H 'If-Match: *' 'http://localhost:8080/etag/abc'
HTTP/1.1 200 OK

$ curl -I -H 'If-Match: "abc"' 'http://localhost:8080/etag/abc'
HTTP/1.1 200 OK

$ curl -I -H 'If-Match: "efg"' 'http://localhost:8080/etag/abc'
HTTP/1.1 412 PRECONDITION FAILED

$ curl -I -H 'If-None-Match: "abc", "d", "efg"' 'http://localhost:8080/etag/efg'
HTTP/1.1 304 NOT MODIFIED
```

Since usage of both headers at once is indeterminate in the spec, `If-None-Match` is preferred. Modification date is not considered, I just assume the behavior would be as if the last modified date is the present time. 

Let me know what you think!
