### PR TITLE
Add /anything route

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -164,6 +164,14 @@ def view_get():
     return jsonify(get_dict('url', 'args', 'headers', 'origin'))
 
 
+@app.route('/anything')
+@app.route('/anything/<path:anything>')
+def view_anything(anything=None):
+    """Returns request data."""
+
+    return jsonify(get_dict('url', 'args', 'headers', 'origin', 'method'))
+
+
 @app.route('/post', methods=('POST',))
 def view_post():
     """Returns POST Data."""

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -169,7 +169,7 @@ def get_url(request):
 def get_dict(*keys, **extras):
     """Returns request dict of given keys."""
 
-    _keys = ('url', 'args', 'form', 'data', 'origin', 'headers', 'files', 'json')
+    _keys = ('url', 'args', 'form', 'data', 'origin', 'headers', 'files', 'json', 'method')
 
     assert all(map(_keys.__contains__, keys))
     data = request.data
@@ -188,7 +188,8 @@ def get_dict(*keys, **extras):
         origin=request.headers.get('X-Forwarded-For', request.remote_addr),
         headers=get_headers(),
         files=get_files(),
-        json=_json
+        json=_json,
+        method=request.method,
     )
 
     out_d = dict()

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -20,6 +20,8 @@
 <li><code>/patch</code> Returns PATCH data.</li>
 <li><code>/put</code> Returns PUT data.</li>
 <li><code>/delete</code> Returns DELETE data</li>
+<li><a href="{{ url_for('view_anything') }}" data-bare-link="true"><code>/anything</code></a> Returns request data, including method used.</li>
+<li><code>/anything/:anything</code> Returns request data, including the URL.</li>
 <li><a href="{{ url_for('encoding') }}"><code>/encoding/utf8</code></a> Returns page containing UTF-8 data.</li>
 <li><a href="{{ url_for('view_gzip_encoded_content') }}" data-bare-link="true"><code>/gzip</code></a> Returns gzip-encoded data.</li>
 <li><a href="{{ url_for('view_deflate_encoded_content') }}" data-bare-link="true"><code>/deflate</code></a> Returns deflate-encoded data.</li>

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -149,6 +149,20 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(data['url'], 'http://localhost/get')
         self.assertTrue(response.data.endswith(b'\n'))
 
+    def test_anything(self):
+        response = self.app.get('/anything')
+        self.assertEqual(response.status_code, 200)
+        response = self.app.get('/anything/foo/bar')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['args'], {})
+        self.assertEqual(data['headers']['Host'], 'localhost')
+        self.assertEqual(data['headers']['Content-Type'], '')
+        self.assertEqual(data['headers']['Content-Length'], '0')
+        self.assertEqual(data['url'], 'http://localhost/anything/foo/bar')
+        self.assertEqual(data['method'], 'GET')
+        self.assertTrue(response.data.endswith(b'\n'))
+
     def test_base64(self):
         greeting = u'Здравствуй, мир!'
         b64_encoded = _string_to_base64(greeting)


### PR DESCRIPTION
This makes it easier to test which HTTP method is being used, and also to test custom URLs.

Unfortunately, it isn't good for testing URLs with special Unicode characters in them, because Flask seems to automatically decode and unescape the URLs.