### PR TITLE
Add env endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 .tox
 *.egg-info
 *.swp
+
+.idea

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -778,6 +778,15 @@ def xml():
     return response
 
 
+@app.route("/env/<env_var>")
+def env(env_var):
+    value = os.getenv(env_var)
+    if value is None:
+        return status_code(404)
+    else:
+        return jsonify({env_var: value})
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=5000)

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -60,6 +60,8 @@
 <li><a href="{{ url_for('image_svg') }}"><code>/image/svg</code></a> Returns a SVG image.</li>
 <li><a href="{{ url_for('view_forms_post') }}" data-bare-link="true"><code>/forms/post</code></a> HTML form that submits to <em>/post</em></li>
 <li><a href="{{ url_for('xml') }}" data-bare-link="true"><code>/xml</code></a> Returns some XML</li>
+<li><a href="{{ url_for('env', env_var="HOME") }}"><code>/env/:env_var</code></a>
+    Returns the value of <em>env_var</em> or <em>404</em> if the environment variable doesn't exist.</li>
 </ul>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -667,8 +667,8 @@ class HttpbinTestCase(unittest.TestCase):
         with _setenv('HTTPBIN_TEST_ENV', "Ok"):
             response = self.app.get('/env/HTTPBIN_TEST_ENV')
             self.assertEqual(response.status_code, 200)
-            json_response = json.loads(self.get_data(response))
-            self.assertEqual(json_response, {"HTTPBIN_TEST_ENV": "Ok"})
+            data = json.loads(response.data.decode('utf-8'))
+            self.assertEqual(data, {"HTTPBIN_TEST_ENV": "Ok"})
 
     def test_env_if_missing(self):
         response = self.app.get('/env/HTTPBIN_TEST_MISSING_ENV')

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -663,5 +663,17 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(parse_multi_value_header('W/"xyzzy", W/"r2d2xxxx", W/"c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('*'), [ "*" ])
 
+    def test_env_if_present(self):
+        with _setenv('HTTPBIN_TEST_ENV', "Ok"):
+            response = self.app.get('/env/HTTPBIN_TEST_ENV')
+            self.assertEqual(response.status_code, 200)
+            json_response = json.loads(self.get_data(response))
+            self.assertEqual(json_response, {"HTTPBIN_TEST_ENV": "Ok"})
+
+    def test_env_if_missing(self):
+        response = self.app.get('/env/HTTPBIN_TEST_MISSING_ENV')
+        self.assertEqual(response.status_code, 404)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `/env` endpoint takes as parameter an environment variable name and returns its value or 404 if the variable doesn't exist.