### PR TITLE
Change base Dockerfile from Python 2 to Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2-alpine
+FROM python:3-alpine
 
 ENV WEB_CONCURRENCY=4
 


### PR DESCRIPTION
As @kennethreitz likes to say:

> The use of Python 3 is highly preferred over Python 2. Consider upgrading
> your applications and infrastructure if you find yourself still using Python
> 2 in production today. If you are using Python 3, congratulations — you are
> indeed a person of excellent taste.