### PR TITLE
Augment response of /anything

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -179,7 +179,7 @@ def view_get():
 def view_anything(anything=None):
     """Returns request data."""
 
-    return jsonify(get_dict('url', 'args', 'headers', 'origin', 'method', 'form', 'data', 'files', 'json'))
+    return jsonify(get_dict('url', 'args', 'headers', 'origin', 'method', 'form', 'data', 'files', 'json', 'files_with_content_type'))
 
 
 @app.route('/post', methods=('POST',))

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -163,6 +163,29 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(data['method'], 'GET')
         self.assertTrue(response.data.endswith(b'\n'))
 
+    def test_anything_file_content_type(self):
+        # Form data is manually built here so we have extra control over the
+        # request input data. This way werkzeug won't bother us.
+        data = '--bound\r\nContent-Disposition: form-data; name="texty"; '
+        data += 'filename="file.txt"\r\nContent-Type: text/plain\r\n\r\n'
+        data += 'This is a test\n--bound--\r\n'
+        response = self.app.post(
+            '/anything',
+            content_type='multipart/form-data; boundary=bound',
+            data=data,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertTrue(len(data['files_with_content_type']) == 1)
+        self.assertTrue('texty' in data['files_with_content_type'])
+        file = data['files_with_content_type']['texty']
+        self.assertTrue('name' in file)
+        self.assertTrue('payload' in file)
+        self.assertTrue('content_type' in file)
+        self.assertEqual(file['name'], 'file.txt')
+        self.assertEqual(file['payload'], 'This is a test')
+        self.assertEqual(file['content_type'], 'text/plain')
+
     def test_base64(self):
         greeting = u'Здравствуй, мир!'
         b64_encoded = _string_to_base64(greeting)


### PR DESCRIPTION
Hi everyone!

A project I'm hacking on already relies on httpbin for testing purposes, and I noticed there's no way to get back the `filename` and `Content-Type` of uploaded files. This PR adds a new field to the response of `/anything`, named `files_with_content_type`. It contains a dictionary having the field as key, and a dictionary containing `name`, `payload`, and `content_type` as its value.

I ended up adding a new field rather than modifying the present one `files`, because I don't know how you folks deal with breaking changes.

PS: `files_with_content_type` is a really long name. Suggestions are welcome! 🙌 

Example:
```
$ curl -F "filedata=@httpbin/procfile;type=plain/text" http://localhost:8000/anything

{
  "args": {},
  "data": "",
  "files": {
    "filedata": "web: gunicorn httpbin:app --log-file - --worker-class=\"egg:meinheld#gunicorn_worker\"\n"
  },
  "files_with_content_type": {
    "filedata": {
      "content_type": "plain/text",
      "name": "procfile",
      "payload": "web: gunicorn httpbin:app --log-file - --worker-class=\"egg:meinheld#gunicorn_worker\"\n"
    }
  },
  "form": {},
  "headers": {
    "Accept": "*/*",
    "Content-Length": "275",
    "Content-Type": "multipart/form-data; boundary=------------------------e632fd2acd4d29f5",
    "Expect": "100-continue",
    "Host": "localhost:8000",
    "User-Agent": "curl/7.55.0"
  },
  "json": null,
  "method": "POST",
  "origin": "127.0.0.1",
  "url": "http://localhost:8000/anything"
}
```
