### PR TITLE
Add back fake cookie and make requiring it conditional

### DIFF
--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -358,7 +358,10 @@ def check_digest_auth(user, passwd):
         credentails = parse_authorization_header(request.headers.get('Authorization'))
         if not credentails:
             return
-        response_hash = response(credentails, passwd, dict(uri=request.script_root + request.path,
+        request_uri = request.script_root + request.path
+        if request.query_string:
+            request_uri +=  '?' + request.query_string
+        response_hash = response(credentails, passwd, dict(uri=request_uri,
                                                            body=request.data,
                                                            method=request.method))
         if credentails.get('response') == response_hash:


### PR DESCRIPTION
Our digest auth endpoint will once again return a fake cookie but will
only require it if the query-string parameter `require-cookie` is
present.

Further, this fixes a bug in the digest auth implementation in httpbin
where we were only considering the path portions of the request-uri in
the specification. RFC 7230 is very clear that the request-uri includes
the query-string if it is present which means it is necessary in our
digest auth handling.

Closes #380