### PR TITLE
Don't require flask-limiter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
     include_package_data = True, # include files listed in MANIFEST.in
     install_requires=[
         'Flask', 'MarkupSafe', 'decorator', 'itsdangerous', 'six', 'brotlipy',
-        'raven[flask]', 'flask_limiter', 'Flask-Common'
+        'raven[flask]', 'Flask-Common'
     ],
 )


### PR DESCRIPTION
The rate limiting code has been ping ponged several times, but
currently it's not there, so there is no reason to require
flask-limiter.

Signed-off-by: Adam Williamson <awilliam@redhat.com>