### PR TITLE
Updated tox and Travis to use py36.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
+dist: trusty
 language: python
 
 sudo: false
-env:
-    - TOXENV=py27
-    - TOXENV=py34
+matrix:
+    include:
+        - python: 2.7
+          env: TOXENV=py27
+        - python: 3.6
+          env: TOXENV=py36
 
 install:
     - travis_retry pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py36
 
 [testenv]
 commands=python test_httpbin.py


### PR DESCRIPTION
Update Python interpreter used in Tox tests from py34 to py36.  3.6 seems to be what is used in the current Docker container.  Not sure what is deployed to sites.

Made equivalent changes to Travis config.  FWIW also locked dist to trusty, and added a matrix to split the 2.7 and 3.6 builds to use exactly those runtimes (possible the tox env was achieving this anyway).