### PR TITLE
Limit python setup.py test to our tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.rst LICENSE AUTHORS requirements.txt
+include README.rst LICENSE AUTHORS requirements.txt test_httpbin.py
 recursive-include httpbin/templates *

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
          'Programming Language :: Python :: 2.7',
          'Programming Language :: Python :: 3.4',
     ],
+    test_suite="test_httpbin",
     packages=find_packages(),
     include_package_data = True, # include files listed in MANIFEST.in
     install_requires=[


### PR DESCRIPTION
Tell unittest.discover specifically what to look for instead of letting
them scan the entirety of our directory (which could have other
dependencies downloaded with their tests that will fail).

Closes #403 

cc @0-wiz-0 if you can test my suggestion in #403 and verify that works, this is the equivalent and we can merge this. 🎉 