### PR TITLE
Send digest-auth challenge for wrong Authorization header

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -519,7 +519,7 @@ def digest_auth(qop=None, user='user', passwd='passwd', algorithm='MD5', stale_a
         credentials = parse_authorization_header(authorization)
 
     if (not authorization or
-            not credentials or
+            not credentials or credentials.type.lower() != 'digest' or
             (require_cookie_handling and 'Cookie' not in request.headers)):
         response = digest_challenge_response(app, qop, algorithm)
         response.set_cookie('stale_after', value=stale_after)

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -306,6 +306,20 @@ class HttpbinTestCase(unittest.TestCase):
                     for stale_after in (None, 1, 4) if algorithm else (None,) :
                         self._test_digest_auth(username, password, qop, algorithm, body, stale_after)
 
+    def test_digest_auth_with_wrong_authorization_type(self):
+        """Sending an non-digest Authorization header to /digest-auth should return a 401"""
+        auth_headers = (
+            ('Authorization', 'Basic 1234abcd'),
+            ('Authorization', ''),
+            ('',  '')
+        )
+        for header in auth_headers:
+            response = self.app.get(
+                '/digest-auth/auth/myname/mysecret',
+                headers={header[0]: header[1]}
+            )
+            self.assertEqual(response.status_code, 401)
+
     def _test_digest_auth(self, username, password, qop, algorithm=None, body=None, stale_after=None):
         uri = self._digest_auth_create_uri(username, password, qop, algorithm, stale_after)
 


### PR DESCRIPTION
This should resolve the issue in #415. We had a regression around when we send digest-auth challenges with #366 and later #392. This will now verify what kind of 'Authorization' header we received and send a challenge if the value isn't `digest xxxxxxxxxx`.