### PR TITLE
document decode_base64 endpoint /base64/:value on the index.html

### DIFF
--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -23,6 +23,7 @@
 <li><code>/delete</code> Returns DELETE data</li>
 <li><a href="{{ url_for('view_anything') }}" data-bare-link="true"><code>/anything</code></a> Returns request data, including method used.</li>
 <li><code>/anything/:anything</code> Returns request data, including the URL.</li>
+<li><a href="{{ url_for('decode_base64', value='aGVsbG8gd29ybGQNCg==') }}"><code>/base64/:value</code></a> Decodes base64url-encoded string.</li>
 <li><a href="{{ url_for('encoding') }}"><code>/encoding/utf8</code></a> Returns page containing UTF-8 data.</li>
 <li><a href="{{ url_for('view_gzip_encoded_content') }}" data-bare-link="true"><code>/gzip</code></a> Returns gzip-encoded data.</li>
 <li><a href="{{ url_for('view_deflate_encoded_content') }}" data-bare-link="true"><code>/deflate</code></a> Returns deflate-encoded data.</li>


### PR DESCRIPTION
I have come to find out that the /base64/:value endpoint isn't documented on the index.html page, I'm suggesting adding this into that page.